### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/mavaze/checkout-counter.png?label=ready&title=Ready)](https://waffle.io/mavaze/checkout-counter?utm_source=badge)
 ### Checkout Counter
 
 Status: In-progress (Prototype stage)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/mavaze/checkout-counter

This was requested by a real person (user mavaze) on waffle.io, we're not trying to spam you.